### PR TITLE
fix logging, only log errors to console and use info for root.

### DIFF
--- a/service/src/main/resources/logback.xml
+++ b/service/src/main/resources/logback.xml
@@ -44,18 +44,16 @@
         </filter>
     </appender>
 
-    <logger name="org.hibernate.type" level="ALL" />
-    <logger name="org.hibernate" level="DEBUG" />
-    <logger name="eu.europa.ec.fisheries.mdr" level="INFO"/>
-
-    <!-- CONSOLE APPENDER -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{0}.%M\(%line\)) %X{userId}- %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{40} %X{userId}- %msg%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="ERROR"/>
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE" />


### PR DESCRIPTION
We can't filter logging to console in wildfly, so log only errors to stdout.