### PR TITLE
introduce property ${hibernate.spatial.dialect} for spatial dialect,

### DIFF
--- a/service/src/main/resources/META-INF/persistence.xml
+++ b/service/src/main/resources/META-INF/persistence.xml
@@ -10,7 +10,7 @@
         <jta-data-source>java:jboss/datasources/uvms_mdr</jta-data-source>
 
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.spatial.dialect.postgis.PostgisDialect"/>
+            <property name="hibernate.dialect" value="${hibernate.spatial.dialect}"/>
             <property name="hibernate.default_schema" value="mdr"/>
             <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.JBossStandAloneJtaPlatform"/>
 


### PR DESCRIPTION
default value now set to <property name="hibernate.spatial.dialect"
value="org.hibernate.spatial.dialect.postgis.PostgisDialect"/>  in
https://github.com/UnionVMS/UVMS-Docker/blob/dev/wildfly-base/src/main/docker/standalone-uvms.xml